### PR TITLE
feat: upgrade zego_zim from ^2.21.1+1 to ^2.28.0

### DIFF
--- a/lib/src/internal/event_center.dart
+++ b/lib/src/internal/event_center.dart
@@ -52,15 +52,15 @@ class ZegoSignalingPluginEventCenter {
     };
     ZIMEventHandler.onMessageReactionsChanged = (
       ZIM zim,
-      List<ZIMMessageReaction> infos,
+      ZIMMessageReactionsChangedEventResult result,
     ) {
       ZegoSignalingLoggerService.logInfo(
-        'onMessageReactionsChanged, infos:$infos',
+        'onMessageReactionsChanged, result:$result',
         tag: 'signaling',
         subTag: 'event center zim',
       );
 
-      passThroughEvent.onMessageReactionsChanged?.call(zim, infos);
+      passThroughEvent.onMessageReactionsChanged?.call(zim, result.reactions);
     };
     // TODO: onReceivePeerMessage is deprecated, use onPeerMessageReceived instead when available
     ZIMEventHandler.onReceivePeerMessage = (

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: zego_uikit_signaling_plugin
 description: ZegoUIKitSignalingPlugin is a low-code plugin collection that provides the signal related function extensions for ZegoUIit, helps you to integarte features easier and faster.
-version: 2.8.20
+version: 2.8.21
 homepage: https://www.zegocloud.com/
 repository: https://github.com/ZEGOCLOUD/zego_uikit_signaling_plugin_flutter
 
@@ -14,7 +14,7 @@ dependencies:
 
   zego_plugin_adapter: ^2.14.2
 
-  zego_zim: ^2.21.1+1
+  zego_zim: ^2.28.0
   zego_zpns: ^2.8.0
   zego_callkit: ^1.0.0+4
 


### PR DESCRIPTION
## Summary

- Upgrade zego_zim dependency from ^2.21.1+1 to ^2.28.0
- Update version to 2.8.21
- Fix API compatibility for zego_zim 2.28.0

## Related
- FEAT-20260427-001: Flutter UIKits ZIM/ZPNS version upgrade

## Verification
- flutter analyze: 0 errors